### PR TITLE
Fix critical error when installing suggested products

### DIFF
--- a/includes/Services/PluginInstaller/InstallPlugin.php
+++ b/includes/Services/PluginInstaller/InstallPlugin.php
@@ -36,6 +36,10 @@ class InstallPlugin {
             require_once wp_normalize_path( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
         }
 
+        if ( ! function_exists( 'request_filesystem_credentials' ) ) {
+            require_once wp_normalize_path( ABSPATH . 'wp-admin/includes/file.php' );
+        }
+
         $upgrader = new \Plugin_Upgrader( new SilentUpgradeSkin() );
         
         // Get plugin information first


### PR DESCRIPTION
## Summary
- Fixed critical error that occurred when attempting to install suggested products (WPForms or Merchant) from the plugin dashboard
- Added missing `wp-admin/includes/file.php` include to resolve `Call to undefined function request_filesystem_credentials()` error

## Changes
- Added proper WordPress admin file includes in `InstallPlugin.php` to ensure all required functions are available in REST API context

See #37