### PR TITLE
Fix Settings tab UI - Editor option now shows proper active state

### DIFF
--- a/assets/js/src/plugin-dashboard/components/Navigation/MainNavigation.jsx
+++ b/assets/js/src/plugin-dashboard/components/Navigation/MainNavigation.jsx
@@ -89,7 +89,7 @@ const styles = (theme) => css`
 const MainNavigation = ( props ) => {
     const { links } = props;
     const theme = useTheme();
-    const [ activePage, setActivePage ] = useContext( PageContext );
+    const [ activePage, setActivePage, activeSection, setActiveSection ] = useContext( PageContext );
     
     return (
         <div className="atb-dashboard__main-navigation" css={ styles(theme) }>
@@ -100,7 +100,10 @@ const MainNavigation = ( props ) => {
                             <Link 
                                 to={ `?page=at-blocks&path=${ link.path }${ link.section ? `&section=${ link.section }` : '' }` }
                                 onClick={ () => { 
-                                    setActivePage( link.path ); 
+                                    setActivePage( link.path );
+                                    if ( link.section ) {
+                                        setActiveSection( link.section );
+                                    }
                                 } }
                             >
                                 {

--- a/assets/js/src/plugin-dashboard/contexts/GlobalContext.jsx
+++ b/assets/js/src/plugin-dashboard/contexts/GlobalContext.jsx
@@ -17,7 +17,21 @@ const useQuery = () => {
 export const GlobalContextProvider = ({ children }) => {
 	const query = useQuery();
 	const [activePage, setActivePage] = useState(query.get('path'));
-	const [activeSection, setActiveSection] = useState(query.get('section'));
+	
+	// Set default activeSection to 'editor-options' when on settings page with no section specified.
+	const getDefaultActiveSection = () => {
+		const section = query.get('section');
+		const path = query.get('path');
+		
+		// If we're on the settings page and no section is specified, default to 'editor-options'.
+		if (path === 'settings' && !section) {
+			return 'editor-options';
+		}
+		
+		return section;
+	};
+	
+	const [activeSection, setActiveSection] = useState(getDefaultActiveSection());
 	const [displaySnackBar, setDisplaySnackBar] = useState(false);
 	const [enabledBlocks, setEnabledBlocks] = useState( athemesBlocksEnabledBlocks || [] );
 	const [settings, setSettings] = useState( athemesBlocksDashboardSettings || {} );


### PR DESCRIPTION
- Fixed GlobalContext to set default activeSection to 'editor-options' when on settings page
- Updated MainNavigation to properly set activeSection when clicking Settings tab
- Resolves issue where Editor option appeared selected but lacked visual active styling

See #38